### PR TITLE
klimtwifi: use proper mic channel for path communication-main-mic

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -381,8 +381,8 @@ INPUT_CHANNEL_MAP {
   </path>
 
   <path name="communication-main-mic">
-    <path name="channel-left" />
-    <path name="builtin-mic" />
+    <path name="channel-right" />
+    <path name="back-mic" />
   </path>
 
   <path name="bt-sco-mic">


### PR DESCRIPTION
textPlus app uses communication-main-mic as it's channel for the mic. This has been tested and working in my current build.